### PR TITLE
Fix surface color scaling

### DIFF
--- a/ReactTable.ino
+++ b/ReactTable.ino
@@ -582,7 +582,8 @@ public:
         uint8_t hue = g_Surface[x][y];
         if (hue == 255) return CRGB::Black;
         CRGB color = ColorFromPalette(m_palette, hue);
-        color %= scaledown;
+        uint8_t scale = (scaledown * 255) / 100;
+        color.nscale8_video(scale);
         return color;
     }
 


### PR DESCRIPTION
## Summary
- adjust brightness calculation in `getSurfaceColor`

## Testing
- `g++ -x c++ -std=c++17 -c ReactTable.ino` *(fails: FastLED.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840896ca9a08331a764098bb264617b